### PR TITLE
Adding instructions on how to link your data to the catalog

### DIFF
--- a/assets/css/common/profile-mode.css
+++ b/assets/css/common/profile-mode.css
@@ -288,6 +288,13 @@
     color: white;
 }
 
+.data-button {
+    background-color: white;
+    padding: 0.5em;
+    border-radius: 10px;
+    box-shadow: rgba(180, 180, 255, 0.25) 0 10px 12px -2px, rgba(255, 248, 248, 0.3) 0 3px 7px -3px;
+}
+
 @media screen and (min-width: 768px) {
     .content-btn:hover .btn-icon {
         transform: translateY(-0.2em);

--- a/config.toml
+++ b/config.toml
@@ -39,6 +39,11 @@ defaultContentLanguageInSubdir = true
       url = "https://data.abcd-j.de/"
       weight = 2
 
+    [[languages.en.menu.main]]
+      name = "Contribute"
+      url = "https://rdm.abcd-j.de/"
+      weight = 3
+
   [languages.de]
     title = "ABCD-J"
     languageName = "Deutsch"
@@ -48,3 +53,8 @@ defaultContentLanguageInSubdir = true
       name = "Daten"
       url = "https://data.abcd-j.de/"
       weight = 2
+
+    [[languages.de.menu.main]]
+      name = "Beitragen"
+      url = "https://rdm.abcd-j.de/"
+      weight = 3

--- a/content/contact.de.md
+++ b/content/contact.de.md
@@ -1,7 +1,7 @@
 ---
 title: "Kontakt"
 menu: "main"
-weight: 5
+weight: 4
 ---
 
 

--- a/content/contact.md
+++ b/content/contact.md
@@ -1,7 +1,7 @@
 ---
 title: "Contact"
 menu: "main"
-weight: 5
+weight: 4
 ---
 
 

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -73,7 +73,8 @@
   weit verbreiteter Dateninfrastruktur zur Verfügung."
 
 - id: about_data_catalog
-  translation: "Der Datenkatalog stellt eine Übersicht über einer Vielzahl erhobener Datensätze dar, die in Partnerinstitutionen erhoben und geteilt wurden."
+  translation: "Der Datenkatalog stellt eine Übersicht über einer Vielzahl erhobener Datensätze dar, 
+            die in Partnerinstitutionen erhoben und geteilt wurden. Wussten Sie, dass Sie Ihre Daten mit dem Katalog verlinken können, ohne sie hochladen zu müssen?"
 
 - id: about_jtrack
   translation: "Die JTrack-Plattform besteht aus den beiden JTrack-Anwendungen EMA und Social, sowie einer Serverstruktur, 
@@ -95,3 +96,6 @@
 - id: funding_text
   translation: "Das ABCD-J-Projekt wird gefördert vom MKW-NRW: Ministerium für Kultur und Wissenschaft des Landes
             Nordrhein-Westfalen im Rahmen des Programms Kooperationsplattformen 2022, Förderkennzeichen: KP22-106A."
+
+- id: data_button
+  translation: "Verlinken Sie Ihre Daten!"

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -68,7 +68,7 @@
 
 - id: about_data_catalog
   translation: "The data catalog showcases a wide variety of datasets collected and shared
-            by partner institutions in the ABCD-J community."
+            by partner institutions in the ABCD-J community. Did you know that you can link your data to the catalog without having to upload it? "
 
 - id: about_jtrack
   translation: "The JTrack platform consists of the two JTrack applications EMA and Social, and a server structure to enable 
@@ -87,3 +87,6 @@
 - id: funding_text
   translation: "The ABCD-J project is funded by the MKW-NRW: Ministerium für Kultur und Wissenschaft des Landes
             Nordrhein-Westfalen under the Kooperationsplattformen 2022 program, grant number: KP22-106A." 
+
+- id: data_button
+  translation: "Link your data!"

--- a/layouts/partials/index_abcdj.html
+++ b/layouts/partials/index_abcdj.html
@@ -193,6 +193,8 @@
                 <div class="content-text">
                     <h1>{{i18n "data_catalog"}}</h1>
                     <p>{{i18n "about_data_catalog"}}</p>
+                    <br>
+                    <a class="data-button" href="https://rdm.abcd-j.de"><i class="fas fa-rocket"></i> &nbsp;{{i18n "data_button"}}</a>
                     <div class="content-buttons">
                         <div class="content-btn">
                             <div class="btn-icon">
@@ -204,10 +206,10 @@
                         </div>
                         <div class="content-btn">
                             <div class="btn-icon">
-                              <a class="fas fa-book" href="https://github.com/abcd-j"></a>
+                              <a class="fas fa-book" href="https://rdm.abcd-j.de"></a>
                             </div>
                             <div class="btn-info">
-                              <h3><a href="https://github.com/abcd-j">Docs</a></h3>
+                              <h3><a href="https://rdm.abcd-j.de">Docs</a></h3>
                             </div>
                         </div>
                         <div class="content-btn">


### PR DESCRIPTION
This PR adds instructions on how to link data to the catalog, the following changes are made to the home page: 

- Adding a menu item called "Contribute" and linking this to https://rdm.abcd-j.de/ user docs
- Under 'ABCD-J Data Catalog' section, adding text and a button which also links to https://rdm.abcd-j.de/; also changed the link under the 'Docs' icon to https://rdm.abcd-j.de/
- Multi-lingual functionality is accounted for with these changes
- Closes #17

Here you can see screenshots of the changes made, in English and German:

<img width="1251" alt="Screenshot 2024-02-09 at 11 43 53" src="https://github.com/abcd-j/website/assets/11378509/7b1e87ab-135e-4aa5-b07f-b08679c9d4c2">
<img width="1212" alt="Screenshot 2024-02-09 at 11 45 51" src="https://github.com/abcd-j/website/assets/11378509/efaf29f8-7a9d-4114-b8b1-7357a4bc0c4b">
<img width="1186" alt="Screenshot 2024-02-09 at 11 46 30" src="https://github.com/abcd-j/website/assets/11378509/045b3ddf-93c1-4c15-8bbf-5b57fb68e110">
<img width="1179" alt="Screenshot 2024-02-09 at 11 47 23" src="https://github.com/abcd-j/website/assets/11378509/cfea013b-3c7c-4c14-8049-b67f2cac7578">

All of these new links lead to the catalog docs:
<img width="1394" alt="Screenshot 2024-02-09 at 11 46 07" src="https://github.com/abcd-j/website/assets/11378509/9be79620-4db8-4aff-8e57-cf73ae328d2d">