### PR TITLE
Fix Duesseldorf partner letters

### DIFF
--- a/content/partners.de.html
+++ b/content/partners.de.html
@@ -105,7 +105,7 @@ weight: 1
             </li>
         </ul>
         <div class="partner-text">
-            <div class="partner-name"><i class="fas fa-b"></i><h3>Prof. Dr. phil. nat. Charlotte von Gall</h3></div>
+            <div class="partner-name"><i class="fas fa-d"></i><h3>Prof. Dr. phil. nat. Charlotte von Gall</h3></div>
             <ul>
                 <li>Direktorin des Instituts für Anatomie II</li>
                 <li>
@@ -114,7 +114,7 @@ weight: 1
             </ul>
         </div>
         <div class="partner-text">
-            <div class="partner-name"><i class="fas fa-b"></i><h3>Dr. med. Eva Meisenzahl-Lechner</h3></div>
+            <div class="partner-name"><i class="fas fa-d"></i><h3>Dr. med. Eva Meisenzahl-Lechner</h3></div>
             <ul>
                 <li>Direktorin der Klinik und Poliklinik für Psychiatrie und Psychotherapie</li>
                 <li>

--- a/content/partners.html
+++ b/content/partners.html
@@ -105,7 +105,7 @@ weight: 1
             </li>
         </ul>
         <div class="partner-text">
-            <div class="partner-name"><i class="fas fa-b"></i><h3>Prof. Dr. phil. nat. Charlotte von Gall</h3></div>
+            <div class="partner-name"><i class="fas fa-d"></i><h3>Prof. Dr. phil. nat. Charlotte von Gall</h3></div>
             <ul>
                 <li>Director of the Institute of Anatomy II</li>
                 <li>
@@ -114,7 +114,7 @@ weight: 1
             </ul>
         </div>
         <div class="partner-text">
-            <div class="partner-name"><i class="fas fa-b"></i><h3>Dr. med. Eva Meisenzahl-Lechner</h3></div>
+            <div class="partner-name"><i class="fas fa-d"></i><h3>Dr. med. Eva Meisenzahl-Lechner</h3></div>
             <ul>
                 <li>Director of the Department of Psychiatry and Psychotherapy</li>
                 <li>


### PR DESCRIPTION
The letters are currently `B` next to Duesseldorf, and should be `D`. This PR fixes that.